### PR TITLE
Replaced broken download link in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         <li><a href="https://github.com/skywalkapps/bootstrap-navbar-toggle">Github</a></li>
         <li>
           <div class="btn-group">
-            <a href="https://github.com/skywalkapps/bootstrap-navbar-toggle/releases/download/v0.9.1/bootstrap-navbar-toggle-0.9.0-dist.zip" class="btn btn-primary navbar-btn" role="button">
+            <a href="https://github.com/skywalkapps/bootstrap-navbar-toggle/archive/v0.9.1.zip" class="btn btn-primary navbar-btn" role="button">
               Download Navbar Toggle v0.9.1
             </a>
           </div>


### PR DESCRIPTION
Now points to https://github.com/skywalkapps/bootstrap-navbar-toggle/archive/v0.9.1.zip, previous link was 404